### PR TITLE
Current package version for HMKIT needs updated

### DIFF
--- a/charger/package.json
+++ b/charger/package.json
@@ -10,6 +10,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "eslint": "^3.19.0",
-    "hmkit": "^0.7.1"
+    "hmkit": "^0.7.2"
   }
 }


### PR DESCRIPTION
I raised an issue where the current application could not successfully connect to the HM API.

This seems to have been addressed in the new package version. 

I updated the package version and it resolved my issue, i was able to successfully get a valid device certificate.